### PR TITLE
Fixed UseConsoleBots setting players on zombie team

### DIFF
--- a/lua/d3bot/sv_zs_bot_handler/supervisor.lua
+++ b/lua/d3bot/sv_zs_bot_handler/supervisor.lua
@@ -101,8 +101,9 @@ function D3bot.MaintainBotRoles()
 		for team, desiredCount in pairs(desiredCountByTeam) do
 			if #(playersByTeam[team] or {}) < desiredCount then
 				if D3bot.UseConsoleBots then
-					RunConsoleCommand("bot")
 					spawnAsTeam = team
+					RunConsoleCommand("bot")
+					spawnAsTeam = nil
 				else
 					spawnAsTeam = team
 					---@type GPlayer|table


### PR DESCRIPTION
Fixed a bug when UseConsoleBots is enabled and everyone else after the 1st person has loaded would be set in into zombie team upon loading